### PR TITLE
center aligned arrow left icon

### DIFF
--- a/CampusShuttleApp/package-lock.json
+++ b/CampusShuttleApp/package-lock.json
@@ -8,6 +8,7 @@
       "name": "campusshuttleapp",
       "version": "1.0.0",
       "dependencies": {
+        "@expo/vector-icons": "^15.0.3",
         "@react-navigation/native": "^6.1.17",
         "@react-navigation/native-stack": "^6.9.26",
         "@tamagui/config": "1.94.3",

--- a/CampusShuttleApp/package.json
+++ b/CampusShuttleApp/package.json
@@ -8,6 +8,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/vector-icons": "^15.0.3",
     "@react-navigation/native": "^6.1.17",
     "@react-navigation/native-stack": "^6.9.26",
     "@tamagui/config": "1.94.3",

--- a/CampusShuttleApp/src/screens/StudentHomeScreen.js
+++ b/CampusShuttleApp/src/screens/StudentHomeScreen.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
 import { useTheme, useNavigation } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
 
 export default function StudentHomeScreen({ toggleTheme, isDarkTheme }) {
   const { colors } = useTheme();
@@ -13,7 +14,10 @@ export default function StudentHomeScreen({ toggleTheme, isDarkTheme }) {
           style={styles.backButton}
           onPress={() => navigation.goBack()}
         >
-          <Text style={[styles.backButtonText, { color: colors.text }]}>← Back</Text>
+          <View style={styles.backButtonContent}>
+            <Ionicons name="arrow-back" size={20} color={colors.text} />
+            <Text style={[styles.backButtonText, { color: colors.text }]}>Back</Text>
+          </View>
         </TouchableOpacity>
         
         <TouchableOpacity style={styles.toggleButton} onPress={toggleTheme}>
@@ -77,6 +81,11 @@ const styles = StyleSheet.create({
   },
   backButton: {
     marginBottom: 0,
+  },
+  backButtonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
   },
   backButtonText: {
     fontSize: 18,

--- a/CampusShuttleApp/src/screens/auth/DriverLoginScreen.js
+++ b/CampusShuttleApp/src/screens/auth/DriverLoginScreen.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
 import { useNavigation, useTheme } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
 
 export default function DriverLoginScreen({ toggleTheme, isDarkTheme }) {
   const navigation = useNavigation();
@@ -17,11 +18,14 @@ export default function DriverLoginScreen({ toggleTheme, isDarkTheme }) {
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <TouchableOpacity
-        style={styles.backButton}
-        onPress={() => navigation.goBack()}
-      >
-        <Text style={[styles.backButtonText, { color: colors.text }]}>← Back</Text>
-      </TouchableOpacity>
+          style={styles.backButton}
+          onPress={() => navigation.goBack()}
+        >
+          <View style={styles.backButtonContent}>
+            <Ionicons name="arrow-back" size={20} color={colors.text} />
+            <Text style={[styles.backButtonText, { color: colors.text }]}>Back</Text>
+          </View>
+        </TouchableOpacity>
 
       <TouchableOpacity
         style={styles.themeToggleButton}
@@ -77,6 +81,11 @@ const styles = StyleSheet.create({
   },
   backButton: {
     marginBottom: 20,
+  },
+  backButtonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
   },
   backButtonText: {
     fontSize: 18,

--- a/CampusShuttleApp/src/screens/auth/StudentLoginScreen.js
+++ b/CampusShuttleApp/src/screens/auth/StudentLoginScreen.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
 import { useNavigation, useTheme } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
 
 export default function StudentLoginScreen({ toggleTheme, isDarkTheme }) {
   const navigation = useNavigation();
@@ -23,7 +24,10 @@ export default function StudentLoginScreen({ toggleTheme, isDarkTheme }) {
         style={styles.backButton}
         onPress={() => navigation.goBack()}
       >
-        <Text style={[styles.backButtonText, { color: colors.primary }]}>← Back</Text>
+        <View style={styles.backButtonContent}>
+          <Ionicons name="arrow-back" size={20} color={colors.text} />
+          <Text style={[styles.backButtonText, { color: colors.primary }]}>Back</Text>
+        </View>
       </TouchableOpacity>
 
       <TouchableOpacity
@@ -89,6 +93,11 @@ const styles = StyleSheet.create({
   },
   backButton: {
     marginBottom: 20,
+  },
+  backButtonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
   },
   backButtonText: {
     fontSize: 18,


### PR DESCRIPTION
Solves #47 

![WhatsApp Image 2025-10-26 at 23 10 41](https://github.com/user-attachments/assets/d80f22f4-b62f-4f01-9f9f-5e81ce4e9836)

Used Expo Vector Icons instead of Tamagui Lucide Icons
because Tamagui Lucide requires React 18, and the project is currently running on React 19, which caused compatibility errors.