### PR TITLE
Fix back button occupying full top space

### DIFF
--- a/CampusShuttleApp/src/screens/auth/DriverLoginScreen.js
+++ b/CampusShuttleApp/src/screens/auth/DriverLoginScreen.js
@@ -173,6 +173,7 @@ const styles = StyleSheet.create({
   },
   backButton: {
     marginBottom: 20,
+    alignSelf: 'flex-start',
   },
   themeToggleButton: {
     position: 'absolute',


### PR DESCRIPTION
after fixing it looks like this

![WhatsApp Image 2025-10-27 at 14 23 55](https://github.com/user-attachments/assets/c5d860e0-bd30-4d6f-844e-2ac2435de0f3)

solves #52 